### PR TITLE
Fraud to Abuse and add some language about APIs that interface with browsers.

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -42,15 +42,15 @@
     <p>
       The mission of the <a href="https://www.w3.org/community/antifraud/">Anti
       Fraud Community Group</a> is to identify and define scenarios involving
-      fraud and unwanted traffic, as well as to incubate and develop web
-      features and APIs to address those scenarios while supporting user
-      security, privacy, and accessibility. Fraud and unwanted traffic can
-      include web activity perpetrated by botnets, attackers impersonating
-      users, and other activity that intends to deceive and harm users or
-      compromise web services.
+      fraud and abuse, such as unwanted traffic, as well as to incubate and 
+      develop web features and APIs to address those scenarios while supporting
+      user security, privacy, and accessibility. Fraud and abuse can include
+      web activity perpetrated by botnets, attackers impersonating
+      users, unwanted traffic, and other activity that intends to deceive and
+      harm users or compromise web services.
     </p>
     <p>
-      The group welcomes participation from anti-fraud service providers,
+      The group welcomes participation from anti-abuse service providers,
       common targets of unwanted traffic, browser vendors, privacy advocates,
       web application developers, web hosting and cloud service providers, and
       other interested parties.
@@ -59,7 +59,7 @@
       The Community Group will discuss issues that server operators (network
       and web server admins) and anti-fraud service providers face in this
       area, as well as ideas for new web features, protocols, and APIs intended
-      for browsers or similar user agents.
+      for and that interface with browsers or similar user agents.
     </p>
     <h2 id="scope-of-work">
       Scope of Work
@@ -76,8 +76,8 @@
     <p>
       Carve-outs (exceptions to restrictions/limitations) for other web
       platform work should be brought up in the appropriate group, rather than
-      as part of the Anti-Fraud CG. Features which don’t interact with the
-      browser (or similar user agent) should be proposed in other standards
+      as part of the Anti-Fraud CG. Features which don't interact at all with
+      the browser (or similar user agent) should be proposed in other standards
       bodies (IETF, etc).
     </p>
     <h2 id="meetings">


### PR DESCRIPTION
Generalize to abuse instead of fraud.

Allow for use cases that interface with the browsers (webviews, etc).

This proposal is to fold in the abuse language changes for now, and then we can amend the charter and scope down to the particular portions of anti-abuse the CG is interested in once we've discussed and adopted a use case document.